### PR TITLE
Development

### DIFF
--- a/DataStore_Containers/API/ReagentBank.lua
+++ b/DataStore_Containers/API/ReagentBank.lua
@@ -91,7 +91,10 @@ AddonFactory:OnAddonLoaded(addonName, function()
 		characterTables = {
 			["DataStore_Containers_Reagents"] = {
 				GetReagentBank = function(character) return character end,
-				GetReagentBankItemCount = function(character, searchedID) return DataStore:GetItemCountByID(character, searchedID) end,
+				--GetReagentBankItemCount = function(character, searchedID) return DataStore:GetItemCountByID(character, searchedID) end,
+				GetReagentBankItemCount = function(character, searchedID)
+					return DataStore:GetItemCountByID(DataStore:GetReagentBank(character), searchedID)
+				end,
 			},
 		},
 	})

--- a/DataStore_Containers/API/ReagentBank.lua
+++ b/DataStore_Containers/API/ReagentBank.lua
@@ -12,7 +12,7 @@ local DataStore, tonumber, wipe, time, C_Container = DataStore, tonumber, wipe, 
 local isRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
 
 local bit64 = LibStub("LibBit64")
-local REAGENT_BANK = Enum.BagIndex.Reagentbank
+local REAGENT_BANK = Enum.BagIndex.Reagentbank or DataStore.Enum.ContainerIDs.ReagentBank
 
 local function GetRemainingCooldown(start)
    local uptime = GetTime()
@@ -58,7 +58,7 @@ end
 local function ScanReagentBank()
 	local bagID = REAGENT_BANK
 	if not bagID then return end
-	
+
 	local bag = thisCharacter
 	wipe(bag.items)
 	wipe(bag.links)

--- a/DataStore_Containers/API/WarbandBank.lua
+++ b/DataStore_Containers/API/WarbandBank.lua
@@ -7,6 +7,7 @@ This file keeps track of an account's warband bank (Retail only).
 local addonName, addon = ...
 local thisCharacter
 local warbank
+local isBankOpen = false
 
 local DataStore, tonumber, wipe, time, C_Container = DataStore, tonumber, wipe, time, C_Container
 
@@ -27,7 +28,7 @@ local TAB_SIZE = 98
 
 local function ScanAccountBankTab(tabID)
 	local tab = GetBankTab(tabID)
-	if not tab then return end
+	if not tab or not isBankOpen then return end
 
 	wipe(tab.items)				-- clean existing tab data
 	wipe(tab.links)
@@ -144,11 +145,13 @@ AddonFactory:OnPlayerLogin(function()
 	addon:ListenTo("PLAYER_INTERACTION_MANAGER_FRAME_SHOW", function(event, interactionType)
 		-- .Banker when interacting with a banker in a capital
 		-- .AccountBanker when interacting with the remote portal
-		
 		if interactionType == Enum.PlayerInteractionType.Banker or interactionType == Enum.PlayerInteractionType.AccountBanker then 
+			isBankOpen = true
 			ScanAccountBank()
 		end
 	end)
+	addon:ListenTo("PLAYER_INTERACTION_MANAGER_FRAME_HIDE", function() isBankOpen = false end)
+
 	
 	-- The event is triggered when purchasing a new tab, not sure yet if we need it.
 	addon:ListenTo("PLAYER_ACCOUNT_BANK_TAB_SLOTS_CHANGED", OnAccountBankTabsChanged)

--- a/DataStore_Containers/DataStore_Containers.lua
+++ b/DataStore_Containers/DataStore_Containers.lua
@@ -501,6 +501,7 @@ end
 
 local function _GetItemCountByID(container, searchedID)
 	local count = 0
+	if not container then return count end
 	
 	for slotID, slot in pairs(container.items) do
 		local pos = _GetItemCountPosition(slot)

--- a/DataStore_Containers/DataStore_Containers.lua
+++ b/DataStore_Containers/DataStore_Containers.lua
@@ -366,14 +366,14 @@ else
 	bagTypeStrings = {
 		[1] = "Quiver",
 		[2] = "Ammo Pouch",
-		[4] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER, 1), -- "Soul Bag",
-		[8] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER, 7), -- "Leatherworking Bag",
-		[16] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER, 8), -- "Inscription Bag",
-		[32] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER, 2), -- "Herb Bag"
-		[64] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER, 3), -- "Enchanting Bag",
-		[128] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER, 4), -- "Engineering Bag",
-		[512] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER, 5), -- "Gem Bag",
-		[1024] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER, 6), -- "Mining Bag",
+		[4] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER or Enum.ItemClass.Container, 1), -- "Soul Bag",
+		[8] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER or Enum.ItemClass.Container, 7), -- "Leatherworking Bag",
+		[16] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER or Enum.ItemClass.Container, 8), -- "Inscription Bag",
+		[32] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER or Enum.ItemClass.Container, 2), -- "Herb Bag"
+		[64] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER or Enum.ItemClass.Container, 3), -- "Enchanting Bag",
+		[128] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER or Enum.ItemClass.Container, 4), -- "Engineering Bag",
+		[512] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER or Enum.ItemClass.Container, 5), -- "Gem Bag",
+		[1024] = C_Item.GetItemSubClassInfo(LE_ITEM_CLASS_CONTAINER or Enum.ItemClass.Container, 6), -- "Mining Bag",
 	}
 end
 

--- a/DataStore_Containers/DataStore_Containers.toc
+++ b/DataStore_Containers/DataStore_Containers.toc
@@ -1,4 +1,4 @@
-## Interface: 120005, 50503, 20505, 11508
+## Interface: 120005, 50504, 20505, 11508
 ## Title: DataStore_Containers
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 

--- a/DataStore_Containers/DataStore_Containers.toc
+++ b/DataStore_Containers/DataStore_Containers.toc
@@ -1,4 +1,4 @@
-## Interface: 120000, 50503, 20505, 11508
+## Interface: 120001, 120005, 50503, 20505, 11508
 ## Title: DataStore_Containers
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 

--- a/DataStore_Containers/DataStore_Containers.toc
+++ b/DataStore_Containers/DataStore_Containers.toc
@@ -1,4 +1,4 @@
-## Interface: 120001, 120005, 50503, 20505, 11508
+## Interface: 120005, 50503, 20505, 11508
 ## Title: DataStore_Containers
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 

--- a/DataStore_Containers/DataStore_Containers.toc
+++ b/DataStore_Containers/DataStore_Containers.toc
@@ -1,4 +1,4 @@
-## Interface: 120005, 50504, 20505, 11508
+## Interface: 120007, 50504, 20505, 11508
 ## Title: DataStore_Containers
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 

--- a/DataStore_Containers/DataStore_Containers.toc
+++ b/DataStore_Containers/DataStore_Containers.toc
@@ -1,10 +1,10 @@
-## Interface: 110205, 50501, 11507
+## Interface: 110207, 50503, 20505, 11508
 ## Title: DataStore_Containers
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 
 ## Notes: Stores information about character bags, bank, and guild banks
 ## Author: Thaoky (EU-Marécages de Zangar)
-## Version: 2025.10.19
+## Version: 2026.01.16
 ## Dependencies: AddonFactory, DataStore
 ## SavedVariables: DataStore_Containers_Characters, DataStore_Containers_Banks, DataStore_Containers_Guilds, DataStore_Containers_Reagents, DataStore_Containers_VoidStorage, DataStore_Containers_Keystones, DataStore_Containers_BankTypes, DataStore_Containers_Warbank
 ## X-Category: Interface Enhancements

--- a/DataStore_Containers/Enum.lua
+++ b/DataStore_Containers/Enum.lua
@@ -5,10 +5,10 @@ Container-related enumerations
 local enum = DataStore.Enum
 
 enum.ContainerIDs = {
-	MainBankSlots = -1,		-- bag id of the 28 main bank slots
-	Keyring = -2,				-- keyring bag id (non-retail)
+	MainBankSlots = Enum.BagIndex.Characterbanktab or -1,		-- bag id of the main bank slots (originally 28, now 98)
+	Keyring = Enum.BagIndex.Keyring or -2,				-- keyring bag id (non-retail)
 	VoidStorageTab1 = -5,	-- bag id for the void storage (arbitrary)
 	VoidStorageTab2 = -6,	-- bag id for the void storage (arbitrary)
-	ReagentBank = -7,
+	ReagentBank = -7,  -- this should have been -3 before 11.2?
 	ReagentBag = 5,
 }


### PR DESCRIPTION
ScanAccountBankTab adjusted to check for an open bank tab
Adjusted bank bag sizes to work with Classic and Retail
Adjusted bagTypeStrings to use Blizzard enum or DataStore's if Blizzard's doesn't exist
Forced bag wipes for bags that don't exist